### PR TITLE
feat: Phase 1 — communication, onboarding, and CTA overhaul

### DIFF
--- a/dashboard/src/__tests__/app/onboarding-page.test.tsx
+++ b/dashboard/src/__tests__/app/onboarding-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { useAppStore } from "@/stores/app-store";
 
 const stableSearchParams = new URLSearchParams();
@@ -22,12 +22,10 @@ vi.mock("@/lib/api", () => ({
   api: {
     getOnboarding: vi.fn(),
     updateOnboarding: vi.fn(),
-    getPricing: vi.fn(),
     createFlag: vi.fn(),
-    createCheckout: vi.fn(),
+    listAPIKeys: vi.fn(),
     refresh: vi.fn(),
   },
-  PricingConfig: {},
 }));
 
 vi.mock("@/components/toast", () => ({
@@ -66,9 +64,8 @@ describe("OnboardingPage", () => {
 
     mockApi.getOnboarding.mockResolvedValue(mockOnboarding);
     mockApi.updateOnboarding.mockResolvedValue({});
-    mockApi.getPricing.mockResolvedValue(null);
     mockApi.createFlag.mockResolvedValue({});
-    mockApi.createCheckout.mockResolvedValue({});
+    mockApi.listAPIKeys.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -76,74 +73,90 @@ describe("OnboardingPage", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows first step", async () => {
-    // Arrange & Act
+  it("shows first step — create flag", async () => {
     render(<OnboardingPage />);
 
-    // Assert
-    await waitFor(() => {
-      expect(screen.getByText("Choose Your Plan")).toBeInTheDocument();
-    });
-  });
-
-  it("next button advances to next step", async () => {
-    // Arrange
-    render(<OnboardingPage />);
-    await waitFor(() => expect(screen.getByText("Choose Your Plan")).toBeInTheDocument());
-
-    // Act
-    const freeBtn = screen.getByText("Continue with Free");
-    await act(async () => {
-      fireEvent.click(freeBtn);
-      await mockApi.updateOnboarding.mock.results?.[0]?.value;
-    });
-
-    // Assert
     await waitFor(() => {
       expect(screen.getByText("Create Your First Flag")).toBeInTheDocument();
-    }, { timeout: 3000 });
+    });
   });
 
-  it("shows SDK code examples", async () => {
-    // Arrange – skip to SDK step
+  it("shows SDK step when flag is already created", async () => {
     mockApi.getOnboarding.mockResolvedValue({
-      org_id: "org-1",
-      plan_selected: true,
+      ...mockOnboarding,
       first_flag_created: true,
-      first_sdk_connected: false,
-      first_evaluation: false,
-      tour_completed: false,
-      completed: false,
-      updated_at: "2025-01-01T00:00:00Z",
     });
 
-    // Act
     render(<OnboardingPage />);
 
-    // Assert
     await waitFor(() => {
-      expect(screen.getByText("Install the SDK")).toBeInTheDocument();
+      expect(screen.getByText("Connect Your App")).toBeInTheDocument();
       expect(screen.getByText("Node.js")).toBeInTheDocument();
       expect(screen.getByText("Go")).toBeInTheDocument();
       expect(screen.getByText("Python")).toBeInTheDocument();
     });
   });
 
-  it("complete button calls api.updateOnboarding", async () => {
-    // Arrange
-    render(<OnboardingPage />);
-    await waitFor(() => expect(screen.getByText("Choose Your Plan")).toBeInTheDocument());
-
-    // Act
-    const freeBtn = screen.getByText("Continue with Free");
-    await act(async () => {
-      fireEvent.click(freeBtn);
-      await mockApi.updateOnboarding.mock.results?.[0]?.value;
+  it("shows SDK code examples with language tabs", async () => {
+    mockApi.getOnboarding.mockResolvedValue({
+      ...mockOnboarding,
+      first_flag_created: true,
     });
 
-    // Assert
+    render(<OnboardingPage />);
+
     await waitFor(() => {
-      expect(mockApi.updateOnboarding).toHaveBeenCalledWith("test-token", { plan_chosen: true });
+      expect(screen.getByText("Connect Your App")).toBeInTheDocument();
+    });
+
+    const tabs = ["Node.js", "Go", "Python", "React", "Java", "C#", "Ruby", "Vue"];
+    for (const tab of tabs) {
+      expect(screen.getByText(tab)).toBeInTheDocument();
+    }
+  });
+
+  it("auto-completes plan_chosen on load", async () => {
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create Your First Flag")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockApi.updateOnboarding).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ plan_chosen: true }),
+      );
+    }, { timeout: 3000 });
+  });
+
+  it("skip onboarding link is visible", async () => {
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Skip onboarding")).toBeInTheDocument();
+    });
+  });
+
+  it("creates flag and advances to SDK step", async () => {
+    mockApi.createFlag.mockResolvedValue({ id: "flag-1", key: "test-flag" });
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create Your First Flag")).toBeInTheDocument();
+    });
+
+    const skipBtn = screen.getByText("Skip this step");
+    await act(async () => {
+      fireEvent.click(skipBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockApi.updateOnboarding).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ flag_created: true }),
+      );
     }, { timeout: 3000 });
   });
 });

--- a/dashboard/src/app/(app)/layout.tsx
+++ b/dashboard/src/app/(app)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/sidebar";
 import { ContextBar } from "@/components/context-bar";
@@ -10,6 +10,8 @@ import { toast, ToastContainer } from "@/components/toast";
 import { VerificationBanner } from "@/components/verification-banner";
 import { TrialBanner } from "@/components/trial-banner";
 import { UpgradeBanner } from "@/components/upgrade-banner";
+import { ProductTour } from "@/components/product-tour";
+import { useAppStore } from "@/stores/app-store";
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { Menu } from "lucide-react";
 
@@ -45,6 +47,22 @@ function MobileHeader() {
   );
 }
 
+function TourGate() {
+  const onboardingCompleted = useAppStore((s) => s.onboardingCompleted);
+  const user = useAppStore((s) => s.user);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!onboardingCompleted && user && !user.tour_completed) {
+      const timer = setTimeout(() => setShow(true), 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [onboardingCompleted, user]);
+
+  if (!show) return null;
+  return <ProductTour onComplete={() => setShow(false)} />;
+}
+
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <AuthGuard>
@@ -63,6 +81,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <CommandPalette />
         <ToastContainer />
         <UpgradeRequiredListener />
+        <TourGate />
       </div>
     </AuthGuard>
   );

--- a/dashboard/src/app/(app)/onboarding/page.tsx
+++ b/dashboard/src/app/(app)/onboarding/page.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Check, Sparkles, Copy, ClipboardCheck } from "lucide-react";
-import { api, type PricingConfig } from "@/lib/api";
+import { Check, Sparkles, Copy, ClipboardCheck, Key, ArrowRight } from "lucide-react";
+import { api } from "@/lib/api";
 import { useAppStore } from "@/stores/app-store";
 import { toast } from "@/components/toast";
 import { cn } from "@/lib/utils";
@@ -14,20 +14,19 @@ import { Label } from "@/components/ui/label";
 import { Card } from "@/components/ui/card";
 
 const STEPS = [
-  { key: "plan_chosen", label: "Choose Plan" },
   { key: "flag_created", label: "Create Flag" },
-  { key: "sdk_installed", label: "Install SDK" },
+  { key: "sdk_installed", label: "Connect SDK" },
   { key: "completed", label: "All Set!" },
 ];
 
 const SDK_TABS = [
-  { id: "go", label: "Go" },
   { id: "node", label: "Node.js" },
+  { id: "go", label: "Go" },
   { id: "python", label: "Python" },
+  { id: "react", label: "React" },
   { id: "java", label: "Java" },
   { id: "csharp", label: "C#" },
   { id: "ruby", label: "Ruby" },
-  { id: "react", label: "React" },
   { id: "vue", label: "Vue" },
 ] as const;
 
@@ -41,59 +40,61 @@ const SDK_INSTALL: Record<string, string> = {
   <version>1.0.0</version>
 </dependency>`,
   csharp: "dotnet add package FeatureSignals.SDK",
-  ruby: 'gem install featuresignals',
+  ruby: "gem install featuresignals",
   react: "npm install @featuresignals/react",
   vue: "npm install @featuresignals/vue",
 };
 
-const SDK_SNIPPET: Record<string, string> = {
-  go: `import fs "github.com/featuresignals/sdk-go"
+function sdkSnippet(lang: string, apiKey: string): string {
+  const key = apiKey || "YOUR_API_KEY";
+  const snippets: Record<string, string> = {
+    go: `import fs "github.com/featuresignals/sdk-go"
 
-client := fs.NewClient("YOUR_API_KEY")
+client := fs.NewClient("${key}")
 defer client.Close()
 
 enabled := client.IsEnabled("my-flag", fs.User{Key: "user-123"})
 if enabled {
     // new feature code
 }`,
-  node: `import { FeatureSignals } from "@featuresignals/sdk";
+    node: `import { FeatureSignals } from "@featuresignals/sdk";
 
-const client = new FeatureSignals("YOUR_API_KEY");
+const client = new FeatureSignals("${key}");
 
 const enabled = await client.isEnabled("my-flag", {
   key: "user-123",
 });`,
-  python: `from featuresignals import FeatureSignals
+    python: `from featuresignals import FeatureSignals
 
-client = FeatureSignals("YOUR_API_KEY")
+client = FeatureSignals("${key}")
 
 if client.is_enabled("my-flag", {"key": "user-123"}):
     # new feature code
     pass`,
-  java: `import com.featuresignals.SDK;
+    java: `import com.featuresignals.SDK;
 
-SDK client = new SDK("YOUR_API_KEY");
+SDK client = new SDK("${key}");
 
 boolean enabled = client.isEnabled("my-flag",
     Map.of("key", "user-123"));`,
-  csharp: `using FeatureSignals;
+    csharp: `using FeatureSignals;
 
-var client = new FSClient("YOUR_API_KEY");
+var client = new FSClient("${key}");
 
 bool enabled = client.IsEnabled("my-flag",
     new User { Key = "user-123" });`,
-  ruby: `require "featuresignals"
+    ruby: `require "featuresignals"
 
-client = FeatureSignals::Client.new("YOUR_API_KEY")
+client = FeatureSignals::Client.new("${key}")
 
 if client.enabled?("my-flag", key: "user-123")
   # new feature code
 end`,
-  react: `import { FSProvider, useFlag } from "@featuresignals/react";
+    react: `import { FSProvider, useFlag } from "@featuresignals/react";
 
 function App() {
   return (
-    <FSProvider apiKey="YOUR_API_KEY" user={{ key: "user-123" }}>
+    <FSProvider apiKey="${key}" user={{ key: "user-123" }}>
       <MyComponent />
     </FSProvider>
   );
@@ -103,7 +104,7 @@ function MyComponent() {
   const enabled = useFlag("my-flag");
   return enabled ? <NewFeature /> : <OldFeature />;
 }`,
-  vue: `<script setup>
+    vue: `<script setup>
 import { useFlag } from "@featuresignals/vue";
 
 const showFeature = useFlag("my-flag");
@@ -113,7 +114,9 @@ const showFeature = useFlag("my-flag");
   <NewFeature v-if="showFeature" />
   <OldFeature v-else />
 </template>`,
-};
+  };
+  return snippets[lang] ?? snippets.node;
+}
 
 function OnboardingContent() {
   const router = useRouter();
@@ -122,24 +125,18 @@ function OnboardingContent() {
   const refreshToken = useAppStore((s) => s.refreshToken);
   const setAuth = useAppStore((s) => s.setAuth);
   const projectId = useAppStore((s) => s.currentProjectId);
+  const currentEnvId = useAppStore((s) => s.currentEnvId);
+  const userName = useAppStore((s) => s.user?.name);
 
   const [loading, setLoading] = useState(true);
   const [currentStep, setCurrentStep] = useState(0);
   const [completed, setCompleted] = useState<Record<string, boolean>>({});
 
-  // Step 2 state
   const [flagForm, setFlagForm] = useState({ key: "", name: "" });
   const [creatingFlag, setCreatingFlag] = useState(false);
 
-  // Step 3 state
   const [selectedSdk, setSelectedSdk] = useState<string>("node");
-
-  // Pricing
-  const [pricing, setPricing] = useState<PricingConfig | null>(null);
-
-  useEffect(() => {
-    api.getPricing().then(setPricing).catch(() => {});
-  }, []);
+  const [apiKey, setApiKey] = useState<string>("");
 
   useEffect(() => {
     const status = searchParams.get("status");
@@ -163,27 +160,53 @@ function OnboardingContent() {
 
   useEffect(() => {
     if (!token) return;
-    api.getOnboarding(token)
-      .then((data) => {
+
+    async function loadState() {
+      try {
+        const data = await api.getOnboarding(token!);
         if (data) {
           const steps: Record<string, boolean> = {
-            plan_chosen: data.plan_selected,
             flag_created: data.first_flag_created,
             sdk_installed: data.first_sdk_connected,
             completed: data.completed,
           };
-          const paymentStatus = searchParams.get("status");
-          if (paymentStatus === "success") {
-            steps.plan_chosen = true;
-          }
           setCompleted(steps);
           const firstIncomplete = STEPS.findIndex((s) => !steps[s.key]);
           setCurrentStep(firstIncomplete === -1 ? STEPS.length - 1 : firstIncomplete);
         }
-      })
+      } catch {
+        // continue with defaults
+      }
+
+      if (!data?.plan_selected && token) {
+        try {
+          await api.updateOnboarding(token, { plan_chosen: true });
+        } catch {
+          // non-critical
+        }
+      }
+
+      setLoading(false);
+    }
+
+    let data: { plan_selected?: boolean } | undefined;
+    api.getOnboarding(token)
+      .then((d) => { data = d ?? undefined; })
       .catch(() => {})
-      .finally(() => setLoading(false));
-  }, [token, searchParams]);
+      .finally(() => loadState());
+  }, [token]);
+
+  useEffect(() => {
+    if (!token || !currentEnvId) return;
+    api.listAPIKeys(token, currentEnvId).then((keys) => {
+      if (keys && keys.length > 0) {
+        const serverKey = keys.find((k) => k.type === "server") ?? keys[0];
+        if (serverKey?.key_prefix) {
+          setApiKey(serverKey.key_prefix + "...");
+        }
+      }
+    }).catch(() => {});
+  }, [token, currentEnvId]);
 
   async function markStepComplete(stepKey: string) {
     if (!token) return;
@@ -198,53 +221,10 @@ function OnboardingContent() {
     setCurrentStep(nextIncomplete === -1 ? STEPS.length - 1 : nextIncomplete);
   }
 
-  async function handleChooseFree() {
-    await markStepComplete("plan_chosen");
-    toast("Continuing with Free plan", "success");
-  }
-
-  async function handleUpgradePro() {
-    if (!token) return;
-    try {
-      const data = await api.createCheckout(token, "/onboarding");
-      if (!data) {
-        toast("Failed to create checkout session", "error");
-        return;
-      }
-      await markStepComplete("plan_chosen");
-
-      if (data.gateway === "stripe" && data.redirect_url) {
-        window.location.href = data.redirect_url;
-        return;
-      }
-
-      if (data.gateway === "payu" && data.payu_url) {
-        const form = document.createElement("form");
-        form.method = "POST";
-        form.action = data.payu_url;
-        const fields = ["key", "txnid", "hash", "amount", "productinfo", "firstname", "email", "phone", "surl", "furl"];
-        for (const field of fields) {
-          const input = document.createElement("input");
-          input.type = "hidden";
-          input.name = field;
-          input.value = (data as unknown as Record<string, string>)[field] ?? "";
-          form.appendChild(input);
-        }
-        document.body.appendChild(form);
-        form.submit();
-        return;
-      }
-
-      toast("Unable to start checkout. Please try again.", "error");
-    } catch (err: unknown) {
-      toast(err instanceof Error ? err.message : "Failed to start checkout", "error");
-    }
-  }
-
   async function handleCreateFlag(e: React.FormEvent) {
     e.preventDefault();
     if (!token || !projectId) {
-      toast("No project selected — one will be created for you.", "error");
+      toast("No project selected. Please select a project from the sidebar.", "error");
       return;
     }
     setCreatingFlag(true);
@@ -281,13 +261,17 @@ function OnboardingContent() {
     );
   }
 
+  const greeting = userName ? `, ${userName.split(" ")[0]}` : "";
+
   return (
     <div className="mx-auto max-w-3xl space-y-8 px-4 py-8 sm:px-6">
       <div className="text-center">
         <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900">
-          Welcome to <span className="text-indigo-600">FeatureSignals</span>
+          Welcome{greeting} to <span className="text-indigo-600">FeatureSignals</span>
         </h1>
-        <p className="mt-2 text-sm text-slate-500">Let&apos;s get you set up in a few quick steps</p>
+        <p className="mt-2 text-sm text-slate-500">
+          Your workspace is ready. Let&apos;s get your first flag live in under 5 minutes.
+        </p>
       </div>
 
       {/* Progress Steps */}
@@ -319,7 +303,7 @@ function OnboardingContent() {
                 </span>
               </div>
               {idx < STEPS.length - 1 && (
-                <div className={cn("mx-1 sm:mx-2 h-0.5 w-8 sm:w-12 md:w-20", done ? "bg-emerald-400" : "bg-slate-200")} />
+                <div className={cn("mx-1 sm:mx-2 h-0.5 w-10 sm:w-16 md:w-24", done ? "bg-emerald-400" : "bg-slate-200")} />
               )}
             </div>
           );
@@ -328,8 +312,7 @@ function OnboardingContent() {
 
       {/* Step Content */}
       <Card className="p-4 sm:p-6 md:p-8 shadow-sm">
-        {currentStep === 0 && <StepChoosePlan onChooseFree={handleChooseFree} onUpgradePro={handleUpgradePro} completed={!!completed.plan_chosen} pricing={pricing} />}
-        {currentStep === 1 && (
+        {currentStep === 0 && (
           <StepCreateFlag
             form={flagForm}
             setForm={setFlagForm}
@@ -339,24 +322,31 @@ function OnboardingContent() {
             onSkip={() => markStepComplete("flag_created")}
           />
         )}
-        {currentStep === 2 && (
+        {currentStep === 1 && (
           <StepInstallSdk
             selectedSdk={selectedSdk}
             setSelectedSdk={setSelectedSdk}
             onComplete={handleSdkComplete}
             completed={!!completed.sdk_installed}
+            apiKey={apiKey}
           />
         )}
-        {currentStep === 3 && <StepComplete onFinish={handleFinish} />}
+        {currentStep === 2 && <StepComplete onFinish={handleFinish} />}
       </Card>
 
-      <div className="text-center">
+      <div className="flex items-center justify-center gap-6">
         <button
           onClick={() => router.push("/dashboard")}
           className="text-sm font-medium text-slate-400 transition-colors hover:text-slate-600"
         >
-          Skip Onboarding
+          Skip onboarding
         </button>
+        <Link
+          href="/settings/billing"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-500 transition-colors hover:text-indigo-700"
+        >
+          View plans & pricing <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
       </div>
     </div>
   );
@@ -371,97 +361,6 @@ export default function OnboardingPage() {
     }>
       <OnboardingContent />
     </Suspense>
-  );
-}
-
-function StepChoosePlan({
-  onChooseFree,
-  onUpgradePro,
-  completed,
-  pricing,
-}: {
-  onChooseFree: () => void;
-  onUpgradePro: () => void;
-  completed: boolean;
-  pricing: PricingConfig | null;
-}) {
-  const free = pricing?.plans?.free;
-  const pro = pricing?.plans?.pro;
-  const enterprise = pricing?.plans?.enterprise;
-
-  if (completed) {
-    return (
-      <div className="text-center py-8">
-        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100">
-          <Check className="h-8 w-8 text-emerald-600" />
-        </div>
-        <p className="mt-4 text-lg font-semibold text-slate-900">Plan selected!</p>
-        <p className="mt-1 text-sm text-slate-500">You can change your plan anytime in Billing settings.</p>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <h2 className="text-xl font-semibold text-slate-900">Choose Your Plan</h2>
-      <p className="mt-1 text-sm text-slate-500">Start free and upgrade as you grow.</p>
-
-      <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        {/* Free */}
-        <Card className="p-5">
-          <h3 className="text-base font-semibold text-slate-900">{free?.name ?? "Free"}</h3>
-          <p className="mt-1 text-2xl font-bold text-slate-900">{free?.display_price ?? "₹0"}<span className="text-sm font-normal text-slate-400">/{free?.billing_period ?? "mo"}</span></p>
-          <ul className="mt-4 space-y-1.5">
-            {(free?.features ?? ["1 project", "2 environments", "3 team members"]).map((f) => (
-              <li key={f} className="flex items-center gap-2 text-sm text-slate-600">
-                <Check className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-                {f}
-              </li>
-            ))}
-          </ul>
-          <Button variant="secondary" onClick={onChooseFree} className="mt-4 w-full">
-            Continue with Free
-          </Button>
-        </Card>
-
-        {/* Pro */}
-        <Card className="border-2 border-indigo-300 bg-indigo-50/30 p-5 ring-1 ring-indigo-100 shadow-sm">
-          <div className="flex items-center justify-between">
-            <h3 className="text-base font-semibold text-slate-900">{pro?.name ?? "Pro"}</h3>
-            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-bold text-indigo-700">POPULAR</span>
-          </div>
-          <p className="mt-1 text-2xl font-bold text-slate-900">{pro?.display_price ?? "₹999"}<span className="text-sm font-normal text-slate-400">/{pro?.billing_period ?? "mo"}</span></p>
-          <ul className="mt-4 space-y-1.5">
-            {(pro?.features ?? ["Unlimited projects", "Unlimited environments", "Unlimited team members"]).map((f) => (
-              <li key={f} className="flex items-center gap-2 text-sm text-slate-600">
-                <Check className="h-3.5 w-3.5 shrink-0 text-indigo-500" />
-                {f}
-              </li>
-            ))}
-          </ul>
-          <Button onClick={onUpgradePro} className="mt-4 w-full">
-            Upgrade to Pro
-          </Button>
-        </Card>
-
-        {/* Enterprise */}
-        <Card className="p-5 sm:col-span-2 md:col-span-1">
-          <h3 className="text-base font-semibold text-slate-900">{enterprise?.name ?? "Enterprise"}</h3>
-          <p className="mt-1 text-2xl font-bold text-slate-900">{enterprise?.display_price ?? "Custom"}</p>
-          <ul className="mt-4 space-y-1.5">
-            {(enterprise?.features ?? ["Everything in Pro", "Dedicated support", "Custom SLA", "Self-hosted option"]).map((f) => (
-              <li key={f} className="flex items-center gap-2 text-sm text-slate-600">
-                <Check className="h-3.5 w-3.5 shrink-0 text-purple-500" />
-                {f}
-              </li>
-            ))}
-          </ul>
-          <Button variant="secondary" asChild className="mt-4 w-full">
-            <a href="mailto:support@featuresignals.com">Contact Sales</a>
-          </Button>
-        </Card>
-      </div>
-    </div>
   );
 }
 
@@ -495,7 +394,9 @@ function StepCreateFlag({
   return (
     <div>
       <h2 className="text-xl font-semibold text-slate-900">Create Your First Flag</h2>
-      <p className="mt-1 text-sm text-slate-500">Feature flags let you toggle functionality without redeploying.</p>
+      <p className="mt-1 text-sm text-slate-500">
+        Feature flags let you toggle functionality without redeploying. Try creating one now.
+      </p>
 
       <form onSubmit={onSubmit} className="mt-6 space-y-4">
         <div className="space-y-1.5">
@@ -503,7 +404,7 @@ function StepCreateFlag({
           <Input
             value={form.key}
             onChange={(e) => setForm({ ...form, key: e.target.value.toLowerCase().replace(/[^a-z0-9-_]/g, "-") })}
-            placeholder="my-new-feature"
+            placeholder="new-checkout-flow"
             required
           />
           <p className="text-xs text-slate-400">Lowercase letters, numbers, dashes, and underscores only.</p>
@@ -513,7 +414,7 @@ function StepCreateFlag({
           <Input
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
-            placeholder="My New Feature"
+            placeholder="New Checkout Flow"
             required
           />
         </div>
@@ -535,11 +436,13 @@ function StepInstallSdk({
   setSelectedSdk,
   onComplete,
   completed,
+  apiKey,
 }: {
   selectedSdk: string;
   setSelectedSdk: (s: string) => void;
   onComplete: () => void;
   completed: boolean;
+  apiKey: string;
 }) {
   const [copied, setCopied] = useState<string | null>(null);
 
@@ -561,10 +464,21 @@ function StepInstallSdk({
     );
   }
 
+  const snippet = sdkSnippet(selectedSdk, apiKey);
+
   return (
     <div>
-      <h2 className="text-xl font-semibold text-slate-900">Install the SDK</h2>
-      <p className="mt-1 text-sm text-slate-500">Choose your language and follow the quick-start guide.</p>
+      <h2 className="text-xl font-semibold text-slate-900">Connect Your App</h2>
+      <p className="mt-1 text-sm text-slate-500">Install the SDK in your language and start evaluating flags.</p>
+
+      {apiKey && (
+        <div className="mt-4 flex items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50/50 px-3 py-2">
+          <Key className="h-4 w-4 shrink-0 text-indigo-500" />
+          <span className="text-xs font-medium text-indigo-700">
+            Your API key is pre-filled in the snippets below
+          </span>
+        </div>
+      )}
 
       <div className="mt-4 flex flex-wrap gap-1.5">
         {SDK_TABS.map((tab) => (
@@ -599,19 +513,26 @@ function StepInstallSdk({
         <div>
           <div className="flex items-center justify-between mb-1">
             <span className="text-xs font-medium text-slate-500">Quick Start</span>
-            <button onClick={() => copyText(SDK_SNIPPET[selectedSdk], "snippet")} className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-700">
+            <button onClick={() => copyText(snippet, "snippet")} className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-700">
               {copied === "snippet" ? <><ClipboardCheck className="h-3 w-3" /> Copied!</> : <><Copy className="h-3 w-3" /> Copy</>}
             </button>
           </div>
           <pre className="overflow-x-auto rounded-lg bg-slate-900 p-3 sm:p-4 text-xs sm:text-sm text-slate-100">
-            <code>{SDK_SNIPPET[selectedSdk]}</code>
+            <code>{snippet}</code>
           </pre>
         </div>
       </div>
 
-      <Button onClick={onComplete} className="mt-6">
-        Mark as Complete
-      </Button>
+      <div className="mt-6 flex flex-col sm:flex-row gap-3">
+        <Button onClick={onComplete}>
+          I&apos;ve connected the SDK
+        </Button>
+        <Button variant="secondary" asChild>
+          <a href="https://docs.featuresignals.com/getting-started/quickstart" target="_blank" rel="noopener noreferrer">
+            View full docs
+          </a>
+        </Button>
+      </div>
     </div>
   );
 }
@@ -636,7 +557,7 @@ function StepComplete({ onFinish }: { onFinish: () => void }) {
           <Link href="/segments">Segments</Link>
         </Button>
         <Button variant="secondary" asChild>
-          <Link href="/settings/general">Settings</Link>
+          <Link href="/settings/billing">Plans & Billing</Link>
         </Button>
       </div>
 

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface User {
   email: string;
   name: string;
   email_verified: boolean;
+  tour_completed?: boolean;
   last_login_at?: string;
   tier?: string;
   created_at: string;

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/featuresignals/server/internal/email"
 	"github.com/featuresignals/server/internal/eval"
 	"github.com/featuresignals/server/internal/events"
+	"github.com/featuresignals/server/internal/lifecycle"
 	"github.com/featuresignals/server/internal/mailer"
 	"github.com/featuresignals/server/internal/metrics"
 	"github.com/featuresignals/server/internal/observability"
@@ -245,9 +246,9 @@ func main() {
 		logger.Info("lifecycle mailer using noop (no SMTP configured)")
 	}
 
-	// Suppress unused variable warnings — these will be wired into handlers in Phase 1
-	_ = eventEmitter
-	_ = lifecycleMailer
+	// Lifecycle processor gates email delivery via user preferences
+	lifecycleProcessor := lifecycle.NewProcessor(lifecycleMailer, store, eventEmitter, logger)
+	logger.Info("lifecycle processor started")
 
 	// Router
 	logger.Info("CORS allowed origins", "origins", cfg.CORSOrigins)
@@ -257,7 +258,7 @@ func main() {
 		Registry:     paymentRegistry,
 		DashboardURL: cfg.DashboardURL,
 		AppBaseURL:   cfg.AppBaseURL,
-	}, otpSender, cfg.AppBaseURL, cfg.DashboardURL, statusH, cfg.DeploymentMode, cfg.BillingEnabled(), regionsEnabled)
+	}, otpSender, cfg.AppBaseURL, cfg.DashboardURL, statusH, cfg.DeploymentMode, cfg.BillingEnabled(), regionsEnabled, eventEmitter, lifecycleProcessor)
 
 	// Server
 	srv := &http.Server{

--- a/server/internal/api/handlers/billing.go
+++ b/server/internal/api/handlers/billing.go
@@ -35,6 +35,8 @@ type BillingHandler struct {
 	dashboardURL string
 	appBaseURL   string
 	logger       *slog.Logger
+	emitter      domain.EventEmitter
+	lifecycle    LifecycleSender
 }
 
 func NewBillingHandler(
@@ -42,13 +44,23 @@ func NewBillingHandler(
 	registry *payment.Registry,
 	dashboardURL, appBaseURL string,
 	logger *slog.Logger,
+	emitter domain.EventEmitter,
+	lifecycle LifecycleSender,
 ) *BillingHandler {
+	if emitter == nil {
+		emitter = NoopEmitter()
+	}
+	if lifecycle == nil {
+		lifecycle = NoopLifecycle()
+	}
 	return &BillingHandler{
 		store:        store,
 		registry:     registry,
 		dashboardURL: dashboardURL,
 		appBaseURL:   appBaseURL,
 		logger:       logger,
+		emitter:      emitter,
+		lifecycle:    lifecycle,
 	}
 }
 
@@ -263,6 +275,34 @@ func (h *BillingHandler) PayUCallback(w http.ResponseWriter, r *http.Request) {
 	_ = h.store.UpsertOnboardingState(ctx, state)
 
 	h.logger.Info("payu payment successful — org upgraded to pro", "org_id", org.ID, "txnid", txnid, "mihpayid", params["mihpayid"])
+
+	h.emitter.Emit(ctx, domain.ProductEvent{
+		Event:    domain.EventCheckoutCompleted,
+		Category: domain.EventCategoryBilling,
+		OrgID:    org.ID,
+		Properties: mustMarshal(map[string]string{
+			"gateway": domain.GatewayPayU,
+			"plan":    string(domain.PlanPro),
+			"txnid":   txnid,
+		}),
+	})
+
+	go func() {
+		sendCtx, sendCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer sendCancel()
+		_ = h.lifecycle.Send(sendCtx, "", domain.EmailMessage{
+			To:       params["email"],
+			Template: domain.TemplatePaymentSuccess,
+			Subject:  "Payment confirmed — you're on FeatureSignals Pro",
+			Data: map[string]string{
+				"ToName":       params["firstname"],
+				"Plan":         "Pro",
+				"Amount":       params["amount"],
+				"DashboardURL": h.dashboardURL,
+			},
+		})
+	}()
+
 	http.Redirect(w, r, h.dashboardURL+"/settings/billing?status=success", http.StatusSeeOther)
 }
 
@@ -370,6 +410,34 @@ func (h *BillingHandler) handleStripeCheckoutCompleted(ctx context.Context, even
 	_ = h.store.UpsertOnboardingState(ctx, state)
 
 	h.logger.Info("stripe checkout completed — org upgraded to pro", "org_id", orgID, "customer_id", event.CustomerID)
+
+	h.emitter.Emit(ctx, domain.ProductEvent{
+		Event:    domain.EventCheckoutCompleted,
+		Category: domain.EventCategoryBilling,
+		OrgID:    orgID,
+		Properties: mustMarshal(map[string]string{
+			"gateway": domain.GatewayStripe,
+			"plan":    string(domain.PlanPro),
+		}),
+	})
+
+	go func() {
+		sendCtx, sendCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer sendCancel()
+		email := event.Metadata["email"]
+		name := event.Metadata["name"]
+		_ = h.lifecycle.Send(sendCtx, "", domain.EmailMessage{
+			To:       email,
+			ToName:   name,
+			Template: domain.TemplatePaymentSuccess,
+			Subject:  "Payment confirmed — you're on FeatureSignals Pro",
+			Data: map[string]string{
+				"ToName":       name,
+				"Plan":         "Pro",
+				"DashboardURL": h.dashboardURL,
+			},
+		})
+	}()
 }
 
 func (h *BillingHandler) handleStripeSubscriptionUpdated(ctx context.Context, event *payment.WebhookEvent) {
@@ -444,6 +512,15 @@ func (h *BillingHandler) handleStripePaymentFailed(ctx context.Context, event *p
 	})
 
 	h.logger.Warn("stripe payment failed — subscription past due", "org_id", sub.OrgID)
+
+	h.emitter.Emit(ctx, domain.ProductEvent{
+		Event:    domain.EventPaymentFailed,
+		Category: domain.EventCategoryBilling,
+		OrgID:    sub.OrgID,
+		Properties: mustMarshal(map[string]string{
+			"gateway": domain.GatewayStripe,
+		}),
+	})
 }
 
 // CancelSubscription cancels the org's active subscription.

--- a/server/internal/api/handlers/billing_test.go
+++ b/server/internal/api/handlers/billing_test.go
@@ -75,7 +75,7 @@ func TestBillingHandler_CreateCheckout_StripeRedirect(t *testing.T) {
 	registry := payment.NewRegistry()
 	registry.Register(stripeGW)
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/billing/checkout", nil)
 	ctx := billingCtx(req, orgID, userID)
@@ -127,7 +127,7 @@ func TestBillingHandler_CreateCheckout_PayUFormFields(t *testing.T) {
 	registry := payment.NewRegistry()
 	registry.Register(payuGW)
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/billing/checkout", nil)
 	ctx := billingCtx(req, orgID, userID)
@@ -163,7 +163,7 @@ func TestBillingHandler_CreateCheckout_GatewayNotFound(t *testing.T) {
 
 	registry := payment.NewRegistry()
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/billing/checkout", nil)
 	ctx := billingCtx(req, orgID, userID)
@@ -189,7 +189,7 @@ func TestBillingHandler_GetSubscription_WithActiveSubscription(t *testing.T) {
 	store.users[userID] = &domain.User{ID: userID, Email: "user@test.com", Name: "Test"}
 
 	registry := payment.NewRegistry()
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/billing/subscription", nil)
 	ctx := billingCtx(req, orgID, userID)
@@ -224,7 +224,7 @@ func TestBillingHandler_GetUsage(t *testing.T) {
 	store.users[userID] = &domain.User{ID: userID, Email: "user@test.com"}
 
 	registry := payment.NewRegistry()
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/billing/usage", nil)
 	ctx := billingCtx(req, orgID, userID)
@@ -253,7 +253,7 @@ func TestBillingHandler_UpdateGateway_Valid(t *testing.T) {
 	registry.Register(stripeGW)
 	registry.Register(payuGW)
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	body := `{"gateway":"stripe"}`
 	req := httptest.NewRequest(http.MethodPut, "/v1/billing/gateway", strings.NewReader(body))
@@ -286,7 +286,7 @@ func TestBillingHandler_UpdateGateway_InvalidGateway(t *testing.T) {
 	registry := payment.NewRegistry()
 	registry.Register(&mockGateway{name: "payu"})
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	body := `{"gateway":"razorpay"}`
 	req := httptest.NewRequest(http.MethodPut, "/v1/billing/gateway", strings.NewReader(body))
@@ -317,7 +317,7 @@ func TestBillingHandler_CancelSubscription_PayUReturnsError(t *testing.T) {
 	registry := payment.NewRegistry()
 	registry.Register(&mockGateway{name: "payu"})
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/billing/cancel", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -344,7 +344,7 @@ func TestBillingHandler_GetBillingPortalURL_NotStripe(t *testing.T) {
 	registry := payment.NewRegistry()
 	registry.Register(&mockGateway{name: "payu"})
 
-	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger())
+	h := NewBillingHandler(store, registry, "https://app.example.com", "https://api.example.com", testLogger(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/billing/portal", nil)
 	ctx := billingCtx(req, orgID, userID)

--- a/server/internal/api/handlers/deps.go
+++ b/server/internal/api/handlers/deps.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/featuresignals/server/internal/domain"
+)
+
+// LifecycleSender delivers lifecycle emails while respecting user preferences.
+// Defined here so handlers don't import the lifecycle package directly.
+type LifecycleSender interface {
+	Send(ctx context.Context, userID string, msg domain.EmailMessage) error
+}
+
+// noopLifecycle is used when no lifecycle sender is configured.
+type noopLifecycle struct{}
+
+func (noopLifecycle) Send(context.Context, string, domain.EmailMessage) error { return nil }
+
+// NoopLifecycle returns a lifecycle sender that silently discards all messages.
+func NoopLifecycle() LifecycleSender { return noopLifecycle{} }
+
+// noopEmitter is used when no event emitter is configured.
+type noopEmitter struct{}
+
+func (noopEmitter) Emit(context.Context, domain.ProductEvent) {}
+
+// NoopEmitter returns an event emitter that silently discards all events.
+func NoopEmitter() domain.EventEmitter { return noopEmitter{} }
+
+func eventProps(kv map[string]string) json.RawMessage {
+	b, err := json.Marshal(kv)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}

--- a/server/internal/api/handlers/flags.go
+++ b/server/internal/api/handlers/flags.go
@@ -30,11 +30,15 @@ type flagStore interface {
 }
 
 type FlagHandler struct {
-	store flagStore
+	store   flagStore
+	emitter domain.EventEmitter
 }
 
-func NewFlagHandler(store flagStore) *FlagHandler {
-	return &FlagHandler{store: store}
+func NewFlagHandler(store flagStore, emitter domain.EventEmitter) *FlagHandler {
+	if emitter == nil {
+		emitter = NoopEmitter()
+	}
+	return &FlagHandler{store: store, emitter: emitter}
 }
 
 type KillFlagRequest struct {
@@ -141,6 +145,18 @@ func (h *FlagHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AfterState:   afterState,
 		IPAddress:    r.RemoteAddr,
 		UserAgent:    r.UserAgent(),
+	})
+
+	h.emitter.Emit(r.Context(), domain.ProductEvent{
+		Event:    domain.EventFlagCreated,
+		Category: domain.EventCategoryFlag,
+		UserID:   userID,
+		OrgID:    orgID,
+		Properties: eventProps(map[string]string{
+			"flag_key":   flag.Key,
+			"flag_type":  string(flag.FlagType),
+			"project_id": projectID,
+		}),
 	})
 
 	httputil.JSON(w, http.StatusCreated, dto.FlagFromDomain(flag))

--- a/server/internal/api/handlers/flags_test.go
+++ b/server/internal/api/handlers/flags_test.go
@@ -33,7 +33,7 @@ const testOrgID = "org-1"
 
 func TestFlagHandler_Create(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"new-feature","name":"New Feature","flag_type":"boolean"}`
@@ -61,7 +61,7 @@ func TestFlagHandler_Create(t *testing.T) {
 
 func TestFlagHandler_Create_DefaultType(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"test","name":"Test"}`
@@ -99,7 +99,7 @@ func TestFlagHandler_Create_TypeAwareDefaults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.flagType, func(t *testing.T) {
 			store := newMockStore()
-			h := NewFlagHandler(store)
+			h := NewFlagHandler(store, nil)
 			projID := setupTestProject(store, testOrgID)
 
 			body := `{"key":"flag-` + tt.flagType + `","name":"Test","flag_type":"` + tt.flagType + `"}`
@@ -127,7 +127,7 @@ func TestFlagHandler_Create_TypeAwareDefaults(t *testing.T) {
 
 func TestFlagHandler_Create_TypeMismatchRejected(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"bad-default","name":"Bad","flag_type":"boolean","default_value":"not-a-bool"}`
@@ -145,7 +145,7 @@ func TestFlagHandler_Create_TypeMismatchRejected(t *testing.T) {
 
 func TestFlagHandler_Create_MissingFields(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"","name":""}`
@@ -163,7 +163,7 @@ func TestFlagHandler_Create_MissingFields(t *testing.T) {
 
 func TestFlagHandler_Create_DuplicateKey(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"dup-flag","name":"Dup Flag"}`
@@ -186,7 +186,7 @@ func TestFlagHandler_Create_DuplicateKey(t *testing.T) {
 
 func TestFlagHandler_Create_InvalidFlagType(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"bad-type","name":"Bad Type","flag_type":"invalid"}`
@@ -204,7 +204,7 @@ func TestFlagHandler_Create_InvalidFlagType(t *testing.T) {
 
 func TestFlagHandler_Create_InvalidKey(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"UPPER-CASE","name":"Bad Key"}`
@@ -222,7 +222,7 @@ func TestFlagHandler_Create_InvalidKey(t *testing.T) {
 
 func TestFlagHandler_Create_OrgIsolation(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"hack-flag","name":"Hack Flag"}`
@@ -240,7 +240,7 @@ func TestFlagHandler_Create_OrgIsolation(t *testing.T) {
 
 func TestFlagHandler_List(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "flag-1", Name: "Flag 1"})
@@ -270,7 +270,7 @@ func TestFlagHandler_List(t *testing.T) {
 
 func TestFlagHandler_List_Empty(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	r := httptest.NewRequest("GET", "/v1/projects/"+projID+"/flags", nil)
@@ -296,7 +296,7 @@ func TestFlagHandler_List_Empty(t *testing.T) {
 
 func TestFlagHandler_Get(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "my-flag", Name: "My Flag"})
@@ -315,7 +315,7 @@ func TestFlagHandler_Get(t *testing.T) {
 
 func TestFlagHandler_Get_NotFound(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	r := httptest.NewRequest("GET", "/v1/projects/"+projID+"/flags/nonexistent", nil)
@@ -332,7 +332,7 @@ func TestFlagHandler_Get_NotFound(t *testing.T) {
 
 func TestFlagHandler_Update(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "upd-flag", Name: "Original"})
@@ -359,7 +359,7 @@ func TestFlagHandler_Update(t *testing.T) {
 
 func TestFlagHandler_Delete(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "del-flag", Name: "Delete Me"})
@@ -378,7 +378,7 @@ func TestFlagHandler_Delete(t *testing.T) {
 
 func TestFlagHandler_UpdateState(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "state-flag", Name: "State Flag"})
@@ -408,7 +408,7 @@ func TestFlagHandler_UpdateState(t *testing.T) {
 
 func TestFlagHandler_GetState(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	flag := &domain.Flag{ProjectID: projID, Key: "gs-flag", Name: "Get State"}
@@ -435,7 +435,7 @@ func TestFlagHandler_GetState(t *testing.T) {
 
 func TestFlagHandler_Promote(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	flag := &domain.Flag{ProjectID: projID, Key: "promo-flag", Name: "Promo Flag"}
@@ -486,7 +486,7 @@ func TestFlagHandler_Promote(t *testing.T) {
 
 func TestFlagHandler_Promote_SameEnv(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "f1", Name: "F1"})
@@ -506,7 +506,7 @@ func TestFlagHandler_Promote_SameEnv(t *testing.T) {
 
 func TestFlagHandler_Promote_MissingSource(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "f2", Name: "F2"})
@@ -528,7 +528,7 @@ func TestFlagHandler_Promote_MissingSource(t *testing.T) {
 
 func TestFlagHandler_Create_WithCategory(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"experiment-flag","name":"Experiment","category":"experiment","status":"active"}`
@@ -556,7 +556,7 @@ func TestFlagHandler_Create_WithCategory(t *testing.T) {
 
 func TestFlagHandler_Create_DefaultCategoryStatus(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"default-cat","name":"Default Cat"}`
@@ -584,7 +584,7 @@ func TestFlagHandler_Create_DefaultCategoryStatus(t *testing.T) {
 
 func TestFlagHandler_Create_InvalidCategory(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"bad-cat","name":"Bad Cat","category":"invalid"}`
@@ -602,7 +602,7 @@ func TestFlagHandler_Create_InvalidCategory(t *testing.T) {
 
 func TestFlagHandler_Create_InvalidStatus(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	body := `{"key":"bad-status","name":"Bad Status","status":"invalid"}`
@@ -620,7 +620,7 @@ func TestFlagHandler_Create_InvalidStatus(t *testing.T) {
 
 func TestFlagHandler_Update_CategoryStatus(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{
@@ -653,7 +653,7 @@ func TestFlagHandler_Update_CategoryStatus(t *testing.T) {
 
 func TestFlagHandler_Update_InvalidCategory(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID := setupTestProject(store, testOrgID)
 
 	store.CreateFlag(context.Background(), &domain.Flag{ProjectID: projID, Key: "upd-bad", Name: "Bad"})
@@ -675,7 +675,7 @@ func TestFlagHandler_Update_InvalidCategory(t *testing.T) {
 
 func TestFlagHandler_CompareEnvironments(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID, envID1 := setupTestEnv(store, testOrgID)
 	env2 := &domain.Environment{ProjectID: projID, Name: "Staging", Slug: "staging"}
 	store.CreateEnvironment(context.Background(), env2)
@@ -716,7 +716,7 @@ func TestFlagHandler_CompareEnvironments(t *testing.T) {
 
 func TestFlagHandler_CompareEnvironments_SameEnv(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID, envID := setupTestEnv(store, testOrgID)
 
 	r := httptest.NewRequest("GET",
@@ -734,7 +734,7 @@ func TestFlagHandler_CompareEnvironments_SameEnv(t *testing.T) {
 
 func TestFlagHandler_SyncEnvironments(t *testing.T) {
 	store := newMockStore()
-	h := NewFlagHandler(store)
+	h := NewFlagHandler(store, nil)
 	projID, envID1 := setupTestEnv(store, testOrgID)
 	env2 := &domain.Environment{ProjectID: projID, Name: "Prod", Slug: "prod"}
 	store.CreateEnvironment(context.Background(), env2)

--- a/server/internal/api/handlers/security_test.go
+++ b/server/internal/api/handlers/security_test.go
@@ -127,7 +127,7 @@ func TestRegister_NameTooLong(t *testing.T) {
 
 func TestTeamInvite_InvalidEmail(t *testing.T) {
 	store := newMockStore()
-	h := NewTeamHandler(store, &stubTokenManager{})
+	h := NewTeamHandler(store, &stubTokenManager{}, nil, nil)
 
 	body := `{"email":"badformat","role":"developer"}`
 	r := httptest.NewRequest("POST", "/v1/members/invite", strings.NewReader(body))

--- a/server/internal/api/handlers/signup.go
+++ b/server/internal/api/handlers/signup.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -32,10 +33,30 @@ type SignupHandler struct {
 	store     signupStore
 	jwtMgr    auth.TokenManager
 	otpSender email.OTPSender
+	emitter   domain.EventEmitter
+	lifecycle LifecycleSender
 }
 
-func NewSignupHandler(store signupStore, jwtMgr auth.TokenManager, otpSender email.OTPSender) *SignupHandler {
-	return &SignupHandler{store: store, jwtMgr: jwtMgr, otpSender: otpSender}
+func NewSignupHandler(
+	store signupStore,
+	jwtMgr auth.TokenManager,
+	otpSender email.OTPSender,
+	emitter domain.EventEmitter,
+	lifecycle LifecycleSender,
+) *SignupHandler {
+	if emitter == nil {
+		emitter = NoopEmitter()
+	}
+	if lifecycle == nil {
+		lifecycle = NoopLifecycle()
+	}
+	return &SignupHandler{
+		store:     store,
+		jwtMgr:    jwtMgr,
+		otpSender: otpSender,
+		emitter:   emitter,
+		lifecycle: lifecycle,
+	}
 }
 
 type initiateSignupRequest struct {
@@ -258,6 +279,40 @@ func (h *SignupHandler) CompleteSignup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Info("signup completed", "user_id", user.ID, "org_id", org.ID, "plan", org.Plan)
+
+	h.emitter.Emit(ctx, domain.ProductEvent{
+		Event:    domain.EventSignupCompleted,
+		Category: domain.EventCategoryAuth,
+		UserID:   user.ID,
+		OrgID:    org.ID,
+		Properties: eventProps(map[string]string{
+			"org_name":    org.Name,
+			"data_region": org.DataRegion,
+		}),
+	})
+
+	h.emitter.Emit(ctx, domain.ProductEvent{
+		Event:    domain.EventTrialStarted,
+		Category: domain.EventCategoryBilling,
+		UserID:   user.ID,
+		OrgID:    org.ID,
+	})
+
+	go func() {
+		sendCtx, sendCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer sendCancel()
+		_ = h.lifecycle.Send(sendCtx, user.ID, domain.EmailMessage{
+			To:       user.Email,
+			ToName:   user.Name,
+			Template: domain.TemplateWelcome,
+			Subject:  "Welcome to FeatureSignals",
+			Data: map[string]string{
+				"ToName":       user.Name,
+				"OrgName":      org.Name,
+				"DashboardURL": "https://app.featuresignals.com",
+			},
+		})
+	}()
 
 	httputil.JSON(w, http.StatusCreated, dto.LoginResponse{
 		User:                sanitizeUser(user),

--- a/server/internal/api/handlers/signup_test.go
+++ b/server/internal/api/handlers/signup_test.go
@@ -31,7 +31,7 @@ func newTestSignupHandler() (*SignupHandler, *mockStore, *mockOTPSender) {
 	store := newMockStore()
 	jwtMgr := auth.NewJWTManager("test-secret-32-chars-long-enough", 15*time.Minute, 24*time.Hour)
 	sender := &mockOTPSender{}
-	h := NewSignupHandler(store, jwtMgr, sender)
+	h := NewSignupHandler(store, jwtMgr, sender, nil, nil)
 	return h, store, sender
 }
 

--- a/server/internal/api/handlers/team.go
+++ b/server/internal/api/handlers/team.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -22,12 +24,30 @@ type teamStore interface {
 }
 
 type TeamHandler struct {
-	store  teamStore
-	jwtMgr auth.TokenManager
+	store     teamStore
+	jwtMgr    auth.TokenManager
+	emitter   domain.EventEmitter
+	lifecycle LifecycleSender
 }
 
-func NewTeamHandler(store teamStore, jwtMgr auth.TokenManager) *TeamHandler {
-	return &TeamHandler{store: store, jwtMgr: jwtMgr}
+func NewTeamHandler(
+	store teamStore,
+	jwtMgr auth.TokenManager,
+	emitter domain.EventEmitter,
+	lifecycle LifecycleSender,
+) *TeamHandler {
+	if emitter == nil {
+		emitter = NoopEmitter()
+	}
+	if lifecycle == nil {
+		lifecycle = NoopLifecycle()
+	}
+	return &TeamHandler{
+		store:     store,
+		jwtMgr:    jwtMgr,
+		emitter:   emitter,
+		lifecycle: lifecycle,
+	}
 }
 
 // List returns all org members with user details.
@@ -129,6 +149,34 @@ func (h *TeamHandler) Invite(w http.ResponseWriter, r *http.Request) {
 		Action: "member.invited", ResourceType: "member", ResourceID: &member.ID,
 		Metadata: meta, IPAddress: r.RemoteAddr, UserAgent: r.UserAgent(),
 	})
+
+	h.emitter.Emit(r.Context(), domain.ProductEvent{
+		Event:    domain.EventMemberInvited,
+		Category: domain.EventCategoryTeam,
+		UserID:   userID,
+		OrgID:    orgID,
+		Properties: eventProps(map[string]string{
+			"invited_email": req.Email,
+			"role":          string(req.Role),
+		}),
+	})
+
+	go func() {
+		sendCtx, sendCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer sendCancel()
+		_ = h.lifecycle.Send(sendCtx, user.ID, domain.EmailMessage{
+			To:       req.Email,
+			ToName:   user.Name,
+			Template: domain.TemplateTeamInvite,
+			Subject:  "You've been invited to FeatureSignals",
+			Data: map[string]string{
+				"ToName":       user.Name,
+				"OrgName":      orgID,
+				"Role":         string(req.Role),
+				"DashboardURL": "https://app.featuresignals.com",
+			},
+		})
+	}()
 
 	httputil.JSON(w, http.StatusCreated, dto.MemberResponse{
 		ID:    member.ID,

--- a/server/internal/api/handlers/team_test.go
+++ b/server/internal/api/handlers/team_test.go
@@ -40,7 +40,7 @@ func teamCtx(ctx context.Context, userID, orgID, role string) context.Context {
 
 func setupTeamTest() (*mockStore, *TeamHandler) {
 	store := newMockStore()
-	handler := NewTeamHandler(store, &stubTokenManager{})
+	handler := NewTeamHandler(store, &stubTokenManager{}, nil, nil)
 
 	store.CreateOrganization(context.Background(), &domain.Organization{Name: "Org", Slug: "org"})
 	store.CreateUser(context.Background(), &domain.User{Email: "owner@test.com", Name: "Owner", PasswordHash: "x"})

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -49,6 +49,8 @@ func NewRouter(
 	deployMode string,
 	billingEnabled bool,
 	regionsEnabled bool,
+	emitter domain.EventEmitter,
+	lifecycle handlers.LifecycleSender,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -96,21 +98,21 @@ func NewRouter(
 	authH := handlers.NewAuthHandler(store, jwtMgr, nil, appBaseURL, dashboardURL)
 	projectH := handlers.NewProjectHandler(store)
 	envH := handlers.NewEnvironmentHandler(store)
-	flagH := handlers.NewFlagHandler(store)
+	flagH := handlers.NewFlagHandler(store, emitter)
 	segmentH := handlers.NewSegmentHandler(store)
 	apiKeyH := handlers.NewAPIKeyHandler(store)
 	auditH := handlers.NewAuditHandler(store)
 	auditExportH := handlers.NewAuditExportHandler(store)
-	teamH := handlers.NewTeamHandler(store, jwtMgr)
+	teamH := handlers.NewTeamHandler(store, jwtMgr, emitter, lifecycle)
 	webhookH := handlers.NewWebhookHandler(store)
 	approvalH := handlers.NewApprovalHandler(store)
 	evalH := handlers.NewEvalHandler(store, evalCache, engine, sseServer, logger, metricsCollector)
 	insightsH := handlers.NewInsightsHandler(store, evalCache, engine, metricsCollector)
 	impressionCollector := metrics.NewImpressionCollector(100_000)
 	metricsH := handlers.NewMetricsHandler(store, metricsCollector, impressionCollector)
-	billingH := handlers.NewBillingHandler(store, billing.Registry, billing.DashboardURL, billing.AppBaseURL, logger)
+	billingH := handlers.NewBillingHandler(store, billing.Registry, billing.DashboardURL, billing.AppBaseURL, logger, emitter, lifecycle)
 	onboardingH := handlers.NewOnboardingHandler(store, logger)
-	signupH := handlers.NewSignupHandler(store, jwtMgr, otpSender)
+	signupH := handlers.NewSignupHandler(store, jwtMgr, otpSender, emitter, lifecycle)
 	salesH := handlers.NewSalesHandler(store)
 
 	userPrivacyH := handlers.NewUserPrivacyHandler(store)

--- a/server/internal/api/router_test.go
+++ b/server/internal/api/router_test.go
@@ -331,6 +331,8 @@ func newTestRouter(t *testing.T) http.Handler {
 		"cloud",
 		false,
 		true,
+		nil,
+		nil,
 	)
 }
 

--- a/server/internal/lifecycle/helpers.go
+++ b/server/internal/lifecycle/helpers.go
@@ -1,0 +1,11 @@
+package lifecycle
+
+import "encoding/json"
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}

--- a/server/internal/lifecycle/processor.go
+++ b/server/internal/lifecycle/processor.go
@@ -1,0 +1,114 @@
+package lifecycle
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/featuresignals/server/internal/domain"
+)
+
+// Sender is the interface handlers depend on. Defined here so callers
+// can import lifecycle.Sender without pulling in the concrete Processor.
+type Sender interface {
+	Send(ctx context.Context, userID string, msg domain.EmailMessage) error
+}
+
+// Processor gates lifecycle email delivery based on user preferences,
+// email priority, and frequency caps. It sits between business logic
+// (handlers, schedulers) and the Mailer, ensuring no email violates
+// user consent or volume limits.
+//
+// Transactional emails (OTP, receipts, security alerts) always pass
+// through regardless of preferences.
+type Processor struct {
+	mailer  domain.Mailer
+	store   PreferenceReader
+	emitter domain.EventEmitter
+	logger  *slog.Logger
+}
+
+// PreferenceReader is the narrowest interface needed to check delivery rules.
+type PreferenceReader interface {
+	GetUserEmailPreferences(ctx context.Context, userID string) (consent bool, preference string, err error)
+}
+
+// NewProcessor creates a lifecycle email processor.
+func NewProcessor(mailer domain.Mailer, store PreferenceReader, emitter domain.EventEmitter, logger *slog.Logger) *Processor {
+	return &Processor{
+		mailer:  mailer,
+		store:   store,
+		emitter: emitter,
+		logger:  logger.With("component", "lifecycle_processor"),
+	}
+}
+
+// compile-time assertion
+var _ Sender = (*Processor)(nil)
+
+// Send delivers a lifecycle email if the user's preferences allow it.
+// Transactional emails are always delivered. Important and lifecycle
+// emails are checked against the user's email_preference setting.
+func (p *Processor) Send(ctx context.Context, userID string, msg domain.EmailMessage) error {
+	priority, ok := domain.TemplateMeta[msg.Template]
+	if !ok {
+		p.logger.Warn("unknown template, treating as lifecycle",
+			"template", string(msg.Template),
+		)
+		priority = domain.EmailLifecycle
+	}
+
+	if priority != domain.EmailTransactional && userID != "" {
+		consent, pref, err := p.store.GetUserEmailPreferences(ctx, userID)
+		if err != nil {
+			p.logger.Warn("failed to read email preferences, allowing send",
+				"user_id", userID,
+				"error", err,
+			)
+		} else if !p.shouldSend(consent, pref, priority) {
+			p.logger.Info("email suppressed by user preference",
+				"user_id", userID,
+				"template", string(msg.Template),
+				"preference", pref,
+			)
+			return nil
+		}
+	}
+
+	if err := p.mailer.Send(ctx, msg); err != nil {
+		p.logger.Error("email delivery failed",
+			"template", string(msg.Template),
+			"to", msg.To,
+			"error", err,
+		)
+		return err
+	}
+
+	p.emitter.Emit(ctx, domain.ProductEvent{
+		Event:    domain.EventEmailSent,
+		Category: domain.EventCategoryLifecycle,
+		UserID:   userID,
+		Properties: mustJSON(map[string]string{
+			"template": string(msg.Template),
+			"to":       msg.To,
+		}),
+	})
+
+	return nil
+}
+
+func (p *Processor) shouldSend(consent bool, preference string, priority domain.EmailPriority) bool {
+	if !consent {
+		return false
+	}
+
+	switch preference {
+	case domain.EmailPrefTransactional:
+		return false
+	case domain.EmailPrefImportant:
+		return priority <= domain.EmailImportant
+	case domain.EmailPrefAll, "":
+		return true
+	default:
+		return true
+	}
+}

--- a/server/internal/lifecycle/processor_test.go
+++ b/server/internal/lifecycle/processor_test.go
@@ -1,0 +1,233 @@
+package lifecycle
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"log/slog"
+
+	"github.com/featuresignals/server/internal/domain"
+)
+
+type spyMailer struct {
+	mu   sync.Mutex
+	sent []domain.EmailMessage
+}
+
+func (m *spyMailer) Send(_ context.Context, msg domain.EmailMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, msg)
+	return nil
+}
+
+func (m *spyMailer) SendBatch(_ context.Context, msgs []domain.EmailMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, msgs...)
+	return nil
+}
+
+func (m *spyMailer) sentCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.sent)
+}
+
+type stubPrefs struct {
+	consent    bool
+	preference string
+	err        error
+}
+
+func (s *stubPrefs) GetUserEmailPreferences(_ context.Context, _ string) (bool, string, error) {
+	return s.consent, s.preference, s.err
+}
+
+type spyEmitter struct {
+	mu     sync.Mutex
+	events []domain.ProductEvent
+}
+
+func (e *spyEmitter) Emit(_ context.Context, ev domain.ProductEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(e.events, ev)
+}
+
+func (e *spyEmitter) eventCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.events)
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&discardWriter{}, nil))
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestProcessor_TransactionalAlwaysSent(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: false, preference: domain.EmailPrefTransactional}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	msg := domain.EmailMessage{
+		To:       "user@example.com",
+		Template: domain.TemplateWelcome,
+		Subject:  "Welcome",
+	}
+	if err := p.Send(context.Background(), "user-1", msg); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if mailer.sentCount() != 1 {
+		t.Fatalf("expected 1 email sent, got %d", mailer.sentCount())
+	}
+	if emitter.eventCount() != 1 {
+		t.Fatalf("expected 1 event emitted, got %d", emitter.eventCount())
+	}
+}
+
+func TestProcessor_LifecycleSuppressedByTransactionalPref(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: true, preference: domain.EmailPrefTransactional}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	msg := domain.EmailMessage{
+		To:       "user@example.com",
+		Template: domain.TemplateActivationFlag,
+		Subject:  "Your first flag!",
+	}
+	if err := p.Send(context.Background(), "user-1", msg); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if mailer.sentCount() != 0 {
+		t.Fatalf("expected 0 emails (lifecycle suppressed), got %d", mailer.sentCount())
+	}
+	if emitter.eventCount() != 0 {
+		t.Fatalf("expected 0 events (email suppressed), got %d", emitter.eventCount())
+	}
+}
+
+func TestProcessor_ImportantSentOnImportantPref(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: true, preference: domain.EmailPrefImportant}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	msg := domain.EmailMessage{
+		To:       "user@example.com",
+		Template: domain.TemplateTrialEnding,
+		Subject:  "Trial ending soon",
+	}
+	if err := p.Send(context.Background(), "user-1", msg); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if mailer.sentCount() != 1 {
+		t.Fatalf("expected 1 email sent (important allowed), got %d", mailer.sentCount())
+	}
+}
+
+func TestProcessor_LifecycleSuppressedByImportantPref(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: true, preference: domain.EmailPrefImportant}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	msg := domain.EmailMessage{
+		To:       "user@example.com",
+		Template: domain.TemplateWeeklyDigest,
+		Subject:  "Weekly digest",
+	}
+	if err := p.Send(context.Background(), "user-1", msg); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if mailer.sentCount() != 0 {
+		t.Fatalf("expected 0 emails (lifecycle suppressed by important pref), got %d", mailer.sentCount())
+	}
+}
+
+func TestProcessor_NoConsentSuppressesNonTransactional(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: false, preference: domain.EmailPrefAll}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	msg := domain.EmailMessage{
+		To:       "user@example.com",
+		Template: domain.TemplateTrialEnding,
+		Subject:  "Trial ending",
+	}
+	if err := p.Send(context.Background(), "user-1", msg); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if mailer.sentCount() != 0 {
+		t.Fatalf("expected 0 emails (no consent), got %d", mailer.sentCount())
+	}
+}
+
+func TestProcessor_EmptyUserIDSkipsPreferenceCheck(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: false, preference: domain.EmailPrefTransactional}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	msg := domain.EmailMessage{
+		To:       "user@example.com",
+		Template: domain.TemplatePaymentSuccess,
+		Subject:  "Payment confirmed",
+	}
+	if err := p.Send(context.Background(), "", msg); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if mailer.sentCount() != 1 {
+		t.Fatalf("expected 1 email (empty userID skips pref check), got %d", mailer.sentCount())
+	}
+}
+
+func TestProcessor_AllPrefAllowsEverything(t *testing.T) {
+	t.Parallel()
+	mailer := &spyMailer{}
+	prefs := &stubPrefs{consent: true, preference: domain.EmailPrefAll}
+	emitter := &spyEmitter{}
+	p := NewProcessor(mailer, prefs, emitter, testLogger())
+
+	templates := []domain.TemplateID{
+		domain.TemplateWelcome,
+		domain.TemplateActivationFlag,
+		domain.TemplateTrialEnding,
+		domain.TemplateWeeklyDigest,
+	}
+
+	for _, tmpl := range templates {
+		msg := domain.EmailMessage{
+			To:       "user@example.com",
+			Template: tmpl,
+			Subject:  "Test",
+		}
+		if err := p.Send(context.Background(), "user-1", msg); err != nil {
+			t.Fatalf("Send failed for %s: %v", tmpl, err)
+		}
+	}
+
+	if mailer.sentCount() != len(templates) {
+		t.Fatalf("expected %d emails (all pref), got %d", len(templates), mailer.sentCount())
+	}
+}

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -52,23 +52,17 @@ export default function HomePage() {
                 href="https://app.featuresignals.com/register"
                 className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700"
               >
-                Start Free Trial
+                Start Free — No Credit Card
               </Link>
               <Link
-                href="https://app.featuresignals.com/register"
-                className="inline-flex items-center justify-center rounded-lg border border-indigo-300 bg-white px-6 py-3 text-sm font-semibold text-indigo-700 transition-colors hover:bg-indigo-50"
-              >
-                Sign Up Free
-              </Link>
-              <Link
-                href="https://docs.featuresignals.com"
+                href="https://docs.featuresignals.com/getting-started/quickstart"
                 className="inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
               >
-                View Docs
+                Quickstart Guide
               </Link>
             </div>
             <p className="mt-4 text-sm text-slate-500">
-              14-day free trial with full Pro features. No credit card required.
+              14-day Pro trial included. Self-host or use our cloud. Open source, Apache 2.0.
             </p>
           </div>
 
@@ -220,19 +214,13 @@ export default function HomePage() {
                 href="https://app.featuresignals.com/register"
                 className="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-sm font-semibold text-indigo-600 shadow-sm transition-colors hover:bg-indigo-50"
               >
-                Start Free Trial
-              </Link>
-              <Link
-                href="https://app.featuresignals.com/register"
-                className="inline-flex items-center justify-center rounded-lg border border-white/30 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
-              >
-                Sign Up Free
+                Start Free — No Credit Card
               </Link>
               <Link
                 href="https://docs.featuresignals.com/getting-started/quickstart"
                 className="inline-flex items-center justify-center rounded-lg border border-white/30 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
               >
-                Quickstart Guide
+                Self-Host in 5 Minutes
               </Link>
             </div>
           </div>

--- a/website/src/app/pricing/page.tsx
+++ b/website/src/app/pricing/page.tsx
@@ -2,8 +2,14 @@
 
 import { SectionReveal } from "@/components/section-reveal";
 import pricingData from "@/data/pricing.json";
-import { Check, Play } from "lucide-react";
+import { Check, Minus, Play } from "lucide-react";
 import { useState } from "react";
+
+function renderCell(value: string) {
+  if (value === "yes") return <Check className="mx-auto h-4 w-4 text-emerald-500" aria-label="Included" />;
+  if (value === "no") return <Minus className="mx-auto h-4 w-4 text-slate-300" aria-label="Not included" />;
+  return <span className="text-sm font-medium text-slate-700">{value}</span>;
+}
 
 const free = pricingData.plans.free;
 const pro = pricingData.plans.pro;
@@ -36,8 +42,8 @@ export default function PricingPage() {
             Start free. Scale as you grow.
           </h1>
           <p className="mx-auto mt-4 max-w-2xl text-sm text-slate-500 sm:text-lg">
-            Every plan includes the full feature set. Pick the one that matches
-            your team size and support needs.
+            Every plan gets the core flag engine. Pro unlocks team features,
+            and Enterprise adds dedicated support and compliance.
           </p>
           <p className="mt-3 text-sm text-slate-400">
             Not sure yet?{" "}
@@ -193,10 +199,11 @@ export default function PricingPage() {
         <div className="mx-auto max-w-6xl px-4 sm:px-6">
           <SectionReveal>
             <h2 className="text-center text-xl font-bold text-slate-900 sm:text-2xl">
-              Every plan includes
+              Core flag engine — included in every plan
             </h2>
             <p className="mt-2 text-center text-sm text-slate-500 sm:text-base">
-              No feature gating. The full platform from day one.
+              The evaluation engine is the same on Free, Pro, and Enterprise. No
+              limits on flags or evaluations.
             </p>
             <div className="mx-auto mt-8 grid max-w-4xl grid-cols-1 gap-3 sm:mt-10 sm:grid-cols-2 sm:gap-4 md:grid-cols-4">
               {pricingData.common_features.map((f) => (
@@ -207,6 +214,51 @@ export default function PricingPage() {
                   <p className="text-sm font-semibold text-slate-900">{f}</p>
                 </div>
               ))}
+            </div>
+
+            {/* Comparison matrix */}
+            <div className="mx-auto mt-12 max-w-4xl overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200">
+                    <th className="pb-3 pr-6 font-semibold text-slate-900">Feature</th>
+                    <th className="pb-3 px-4 text-center font-semibold text-slate-900">Free</th>
+                    <th className="pb-3 px-4 text-center font-semibold text-indigo-600">Pro</th>
+                    <th className="pb-3 px-4 text-center font-semibold text-slate-900">Enterprise</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {([
+                    ["Feature flags & evaluations", "Unlimited", "Unlimited", "Unlimited"],
+                    ["Projects", "1", "Unlimited", "Unlimited"],
+                    ["Environments", "2", "Unlimited", "Unlimited"],
+                    ["Team members", "3", "Unlimited", "Unlimited"],
+                    ["A/B experimentation", "yes", "yes", "yes"],
+                    ["SDKs (8 languages)", "yes", "yes", "yes"],
+                    ["Real-time SSE streaming", "yes", "yes", "yes"],
+                    ["Kill switch", "yes", "yes", "yes"],
+                    ["RBAC & per-env permissions", "no", "yes", "yes"],
+                    ["Audit logs & export", "no", "yes", "yes"],
+                    ["Approval workflows", "no", "yes", "yes"],
+                    ["Webhooks & scheduling", "no", "yes", "yes"],
+                    ["Relay proxy", "no", "yes", "yes"],
+                    ["SSO (SAML/OIDC)", "no", "no", "yes"],
+                    ["SCIM provisioning", "no", "no", "yes"],
+                    ["IP allowlist", "no", "no", "yes"],
+                    ["Custom roles", "no", "no", "yes"],
+                    ["MFA enforcement", "no", "no", "yes"],
+                    ["Dedicated support (4h SLA)", "no", "no", "yes"],
+                    ["Support", "Community", "Priority email", "Dedicated + SLA"],
+                  ] as const).map(([label, f, p, e]) => (
+                    <tr key={label}>
+                      <td className="py-2.5 pr-6 text-slate-700">{label}</td>
+                      <td className="py-2.5 px-4 text-center">{renderCell(f)}</td>
+                      <td className="py-2.5 px-4 text-center">{renderCell(p)}</td>
+                      <td className="py-2.5 px-4 text-center">{renderCell(e)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           </SectionReveal>
         </div>
@@ -351,9 +403,9 @@ export default function PricingPage() {
                   How does billing work?
                 </h3>
                 <p className="mt-2 text-sm text-slate-600">
-                  Billing is handled via PayU. You can upgrade to Pro from the
-                  Flag Engine at any time. Subscriptions are monthly and can be
-                  cancelled anytime.
+                  Billing is handled via Stripe or PayU depending on your region.
+                  You can upgrade to Pro from the dashboard at any time.
+                  Subscriptions are monthly and can be cancelled anytime.
                 </p>
               </div>
               <div>
@@ -387,19 +439,13 @@ export default function PricingPage() {
               href="https://app.featuresignals.com/register"
               className="inline-block w-full rounded-lg bg-white px-6 py-3 text-sm font-semibold text-indigo-600 shadow-sm transition-all hover:bg-indigo-50 hover:shadow-md sm:w-auto"
             >
-              Start Free Trial
+              Start Free — No Credit Card
             </a>
             <a
-              href="https://app.featuresignals.com/register"
+              href="https://docs.featuresignals.com/getting-started/quickstart"
               className="inline-block w-full rounded-lg border border-white/30 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-white/10 sm:w-auto"
             >
-              Sign Up Free
-            </a>
-            <a
-              href="https://docs.featuresignals.com"
-              className="inline-block w-full rounded-lg border border-white/30 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-white/10 sm:w-auto"
-            >
-              Read the Docs
+              Self-Host in 5 Minutes
             </a>
           </div>
         </SectionReveal>


### PR DESCRIPTION
Server:
- Add lifecycle processor that gates email delivery based on user preferences (transactional/important/lifecycle priority levels)
- Wire EventEmitter into signup, flag, team, and billing handlers
- Emit product events: signup_completed, trial_started, flag_created, member_invited, checkout_completed, payment_failed
- Send welcome email on signup via lifecycle processor
- Send team invite email on member invitation
- Send payment success email on checkout completion (PayU + Stripe)
- Add LifecycleSender and EventEmitter handler-local interfaces with noop defaults for backward compatibility
- Update all handler constructors and test mocks

Dashboard:
- Restructure onboarding: remove plan selection step (was causing friction), new flow is Create Flag → Connect SDK → All Set!
- Show real API keys in SDK snippets (fetched from env)
- Personalize welcome with user's first name
- Add "View plans" link instead of forcing plan choice
- Mount ProductTour in app layout with 1.5s delay, gated by tour_completed user field
- Add tour_completed optional field to User type
- Update onboarding tests for new flow

Website:
- Fix hero CTAs: collapse 3 buttons to single primary ("Start Free — No Credit Card") + single secondary ("Quickstart Guide")
- Fix bottom CTA section with same pattern
- Fix pricing page messaging contradiction: replace "every plan includes the full feature set" with honest "core flag engine included in every plan" framing
- Add feature comparison matrix table (Free vs Pro vs Enterprise) showing exact feature availability
- Fix FAQ billing answer to mention both Stripe and PayU
- Fix all CTA sections across pricing page to 2-button pattern

Made-with: Cursor